### PR TITLE
OAuth 0.9.64 returns different provider array.

### DIFF
--- a/placid/variables/PlacidVariable.php
+++ b/placid/variables/PlacidVariable.php
@@ -52,7 +52,7 @@ class PlacidVariable
         $providers = craft()->oauth->getProviders();
         $values[null] = 'None';
         foreach($providers as $key => $value) {
-            $values[$key] = $value['name'];
+            $values[$key] = ucfirst($key);
         }
         return $values;
     }


### PR DESCRIPTION
OAuth 0.9.64 no longer has direct access to 'name' key from returned provider array.  Used key for name value.