### PR TITLE
Minor fix to OAuth settings button and breadcrumbs urls

### DIFF
--- a/placid/templates/auth/edit.twig
+++ b/placid/templates/auth/edit.twig
@@ -4,7 +4,7 @@
 
 {% set crumbs = [
     { label: "Placid"|t, url: url('placid/auth') },
-    { label: token ? token.name : 'New token', url: url( token ? '/edit/token/' ~ token.id : 'add') }
+    { label: token ? token.name : 'New token', url: url( token ? 'placid/auth/' ~ token.id : 'placid/auth/new') }
 ] %}
 
 {% set title = token ? token.name : "New access token"|t %}

--- a/placid/templates/oauth/providers-table.twig
+++ b/placid/templates/oauth/providers-table.twig
@@ -25,7 +25,7 @@
 				</td>
 				<td>
 		  			{% if token %}
-		    			<a class="btn small" href="{{ disconnectUrl }}">{{ 'Disconnect from {provider}'|t }}</a>
+		    			<a class="btn small" href="{{ disconnectUrl }}">{{ 'Disconnect from {provider}'|t({provider: provider.name}) }}</a>
 		  			{% else %}
 		    			<a class="btn small" href="{{ connectUrl }}">{{"Connect to {provider}"|t({provider: provider.name})}}</a>
 		  			{% endif %}

--- a/placid/templates/requests/edit.twig
+++ b/placid/templates/requests/edit.twig
@@ -5,7 +5,7 @@
 
 {% set crumbs = [
     { label: "Placid"|t, url: url('placid') },
-    { label: request ? request.name : 'New request', url: url( request ? '/requests/' ~ request.id : 'add') }
+    { label: request ? request.name : 'New request', url: url( request ? 'placid/requests/' ~ request.id : 'placid/requests/new') }
 ] %}
 
 {% set content %}


### PR DESCRIPTION

![screen shot 2015-06-06 at 10 33 58 am](https://cloud.githubusercontent.com/assets/1221575/8017490/10642cf0-0c3a-11e5-865d-b854935603ff.png)


- Fixes the disconnect label for the OAuth settings button (displayed
‘Disconnect from {provider}’
- Fixes for some breadcrumbs links - this occurs when editing an
individual request or Basic Auth item