### PR TITLE
Fix for non-array being stored in params column

### DIFF
--- a/placid/services/Placid_RequestsService.php
+++ b/placid/services/Placid_RequestsService.php
@@ -355,10 +355,13 @@ class Placid_RequestsService extends PlacidService
     // If they exist, add them to the query
     if($cpQuery)
     {
-      foreach($cpQuery as $k => $q)
+      if(is_array($cpQuery))
       {
-        $query->set($q['key'], $q['value']);
-      }
+        foreach($cpQuery as $k => $q)
+        {
+          $query->set($q['key'], $q['value']);
+        }
+      } 
     } 
     elseif(array_key_exists('query', $this->config))
     {


### PR DESCRIPTION
Firstly, you may or may not want to include this as it's a pretty edge-case scenario, so up to you :)

After updating from 1.2.5 to 1.3.5, the templating tags were throwing an error:

```
Internal Server Error
Invalid argument supplied for foreach()
```

Not related, but what was even stranger was that despite devMode being turned on, it showed this error in the Craft-friendly way, rather than giving me useful info - strange.

Looking into the specific code (below), and then checking the database table, it seems like _somehow_ the params column for one of my requests was `Tjs=`. I'm not sure how this got in there, and the Query String table was empty, but as this wasn't an array, it threw an error. I can't even recall setting _any_ query string values in the past.

This PR simply adds a check for an array value before trying to loop over it.