### PR TITLE
added hidden CSRF-field

### DIFF
--- a/placid/manifest.json
+++ b/placid/manifest.json
@@ -1,12 +1,21 @@
 [
   {
+    "version": "1.6.19",
+    "downloadUrl": "https://github.com/alecritson/Placid/archive/master.zip",
+    "date": "2016-01-11T00:00:00+00:00",
+    "notes": [
+        "# Bug Fixes",
+        "[Fixed] Fixed a bug where settings couldn't be saved if CSRF was set to true in the craft configuration."
+    ]
+  },
+  {
       "version": "1.6.18",
       "downloadUrl": "https://github.com/alecritson/Placid/archive/master.zip",
       "date": "2016-01-07T00:00:00+00:00",
       "notes": [
           "# Bug Fixes",
           "[Fixed] Fixed an issue with the `$provider->getToken()` method doesn't exist error",
-          "[Fixed] Cache was broken (sorry) but it's fixed now!",
+          "[Fixed] Cache was broken (sorry) but it's fixed now!"
       ]
   },
   {

--- a/placid/templates/requests/_fields.twig
+++ b/placid/templates/requests/_fields.twig
@@ -1,4 +1,9 @@
-{{ forms.textField({
+    {{ forms.hidden({
+      name: craft.config.csrfTokenName,
+      value: craft.request.csrfToken
+    }) }}
+
+    {{ forms.textField({
       label: 'Name'|t,
       id : 'name',
       required: true,
@@ -26,7 +31,7 @@
       value: request ? request.url : null,
       errors: request ? request.errors('url') : null
     }) }}
-  
+
     {{ forms.editableTableField({
       label: 'Query String',
       instructions : 'Define your query string.',

--- a/placid/templates/requests/edit.twig
+++ b/placid/templates/requests/edit.twig
@@ -14,12 +14,14 @@
   <form method="post" action="" accept-charset="UTF-8" data-saveshortcut="1" data-saveshortcut-redirect="/admin/placid/{% if request %}requests/{{ request.id }}{% endif %}">
     <input type="hidden" name="action" value="placid/requests/saveRequest">
     <input type="hidden" name="redirect" value="placid" />
+    <input type="hidden" name="{{ craft.config.csrfTokenName }}" value="{{ craft.request.csrfToken }}">
+
     {% if request %}
       <input type="hidden" name="requestId" value="{{ request.id }}" />
     {% endif %}
-  
+
     <div class="grid first">
-      
+
         <div class="item" data-position="left" data-min-colspan="2" data-max-colspan="3">
           <div class="pane">
             {% include 'placid/requests/_fields' %}
@@ -50,7 +52,7 @@
                 value : request ? request.tokenId : null,
               }) }}
             {% endif %}
-            
+
           </div>
           <div class="buttons first">
             <input type="submit" class="btn submit" value="{{ 'Save Request'|t }}">


### PR DESCRIPTION
The plugin breaks when editing settings if `'enableCsrfProtection' => true` in the craft config file. This hidden field fixes that, viz. [the CSRF-documentation in craft](https://craftcms.com/support/csrf-protection).
