### PR TITLE
Correct misnamed $token variable.

### DIFF
--- a/placid/services/Placid_RequestsService.php
+++ b/placid/services/Placid_RequestsService.php
@@ -404,7 +404,7 @@ class Placid_RequestsService extends BaseApplicationComponent
       
       $tokenModel = craft()->placid_token->findTokenById($tokenId);
 
-      if(!$token->forceQuery)
+      if(!$tokenModel->forceQuery)
       {
         $request->addHeader('Authorization', 'Bearer ' . $tokenModel->encoded_token);
       }


### PR DESCRIPTION
The if statement was looking for a variable called $token, but it should be $tokenModel. This causes a template error if the user added an access token in Basic Auth and chooses to force the query string.