### PR TITLE
Fixed parsing of XML by adding application/xml content type.

### DIFF
--- a/placid/services/Placid_RequestsService.php
+++ b/placid/services/Placid_RequestsService.php
@@ -134,12 +134,12 @@ class Placid_RequestsService extends BaseApplicationComponent
   {
     $responseBody = $response->getBody();
 
-    $contentType = preg_match('/.+?(?=;)/', $responseBody->getContentType(), $matches);
+    $contentType = preg_match('/.+?(?=;)/', $response->getHeader('content-type'), $matches);
 
     $contentType = implode($matches, '');
     
     try {   
-      if($contentType == 'text/xml')
+      if($contentType == 'text/xml' || $contentType == 'application/xml')
       {
         $output = $response->xml();
       }


### PR DESCRIPTION
Using $response->getHeader('content-type') instead of $responseBody->getContentType()
as the later does not report the content type correctly.

E.g. the following request did not work before this change:

https://jenkins.opengeosys.org/job/OGS-6/job/ufz/job/master/api/xml?pretty=true&tree=builds[displayName,url,keepLog]&exclude=/workflowJob/build[keepLog="false"]